### PR TITLE
Change client_ref key in $payload array to client-ref

### DIFF
--- a/src/Channels/NexmoSmsChannel.php
+++ b/src/Channels/NexmoSmsChannel.php
@@ -59,11 +59,11 @@ class NexmoSmsChannel
             'from' => $message->from ?: $this->from,
             'to' => $to,
             'text' => trim($message->content),
-            'client_ref' => $message->clientReference,
+            'client-ref' => $message->clientReference,
         ];
 
         if ($message->statusCallback) {
-            $payload['client_ref'] = $message->clientReference;
+            $payload['client-ref'] = $message->clientReference;
         }
 
         return ($message->client ?? $this->nexmo)->message()->send($payload);


### PR DESCRIPTION
When I'm sending NexmoMessage with clientReference() method a 'client_ref' parameter is added to my request, but according to Nexmo documentation this parameter should be called 'client-ref' (https://developer.nexmo.com/messaging/sms/guides/delivery-receipts#using-the-sms-api-in-campaigns). 

With 'client_ref' parameter I have got an error 'Undefined index: client_ref' in payload I receive from Nexmo, with 'client-ref' everything works OK.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
